### PR TITLE
Version bump to 3.7.1 - Fix npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-dev-stack",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "AI-powered development environment with 37 specialized agents, intelligent hooks, and unified tooling",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
Version bump to 3.7.1 as 3.7.0 was already published to npm

## Changes
- Updated package.json version to 3.7.1

🤖 Generated with [Claude Code](https://claude.ai/code)