### PR TITLE
Hotfix: Resolve duplicate pythonCmd declaration v3.7.3

### DIFF
--- a/bin/ccds-setup.cjs
+++ b/bin/ccds-setup.cjs
@@ -257,7 +257,7 @@ if (fs.existsSync(claudeConfigPath)) {
     
     // Configure cross-platform statusLine
     const isWindows = process.platform === 'win32';
-    const pythonCmd = isWindows ? 'python' : 'python3';
+    const pythonCmdForStatusline = isWindows ? 'python' : 'python3';
     const statuslineScript = path.join(claudeDir, 'hooks', 'claude_statusline.py');
     
     // Format the command based on OS
@@ -265,10 +265,10 @@ if (fs.existsSync(claudeConfigPath)) {
     if (isWindows) {
       // Windows: Use double quotes and escaped backslashes for settings.json
       const escapedPath = statuslineScript.replace(/\\/g, '\\\\');
-      statuslineCommand = `${pythonCmd} "${escapedPath}"`;
+      statuslineCommand = `${pythonCmdForStatusline} "${escapedPath}"`;
     } else {
       // Linux/macOS: Use the path directly
-      statuslineCommand = `${pythonCmd} ${statuslineScript}`;
+      statuslineCommand = `${pythonCmdForStatusline} ${statuslineScript}`;
     }
     
     config.statusLine = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-dev-stack",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "description": "AI-powered development environment with 37 specialized agents, intelligent hooks, and unified tooling",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Critical Bug Fix
Fixes SyntaxError preventing ccds-setup from running.

## Error
```
SyntaxError: Identifier 'pythonCmd' has already been declared
```

## Solution
Renamed the statusline-specific pythonCmd variable to `pythonCmdForStatusline` to avoid conflict with the existing pythonCmd variable declared later in the file.

## Version
3.7.3

🤖 Generated with [Claude Code](https://claude.ai/code)