### PR TITLE
refactor: Single ccds-setup command v3.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,11 @@
 {
   "name": "claude-code-dev-stack",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "description": "AI-powered development environment with 37 specialized agents, intelligent hooks, and unified tooling",
   "main": "index.js",
   "type": "module",
   "bin": {
     "ccds-setup": "./bin/ccds-setup.cjs",
-    "ccds-detect": "./bin/detect-platform.js",
-    "ccds-install-hooks": "./bin/install-hooks.js",
     "ccds-start": "./bin/ccds-start.js",
     "ccds-stop": "./bin/ccds-stop.js",
     "ccds-tunnel-start": "./bin/ccds-tunnel-start.js",
@@ -29,8 +27,6 @@
   "scripts": {
     "setup": "node bin/ccds-setup.cjs",
     "setup:all": "node scripts/install/complete-install.js",
-    "setup:hooks": "node bin/install-hooks.js",
-    "setup:fix": "node bin/detect-platform.js --fix",
     "test:vm": "bash scripts/test-vm.sh",
     "start": "npm run start:services",
     "start:services": "node scripts/services/start-all-services.js",


### PR DESCRIPTION
## 🎯 ONE Command to Rule Them All

No more multiple commands! Just `ccds-setup` handles EVERYTHING automatically.

## 🔥 What Changed
- **REMOVED** `ccds-detect` command - functionality integrated into setup
- **REMOVED** `ccds-install-hooks` command - setup does this automatically
- **REMOVED** extra npm scripts for fixes - not needed anymore

## ✨ What `ccds-setup` Now Does Automatically
1. Detects your platform (Windows/Linux/Mac/Docker/VM/WSL)
2. Finds the correct Python command
3. Installs all hooks to `~/.claude/hooks/`
4. Configures paths correctly for your OS
5. Sets proper permissions on Unix systems
6. Creates placeholders for missing hooks
7. Configures statusline with proper escaping

## 🚀 Usage
```bash
npm install -g claude-code-dev-stack@latest
ccds-setup  # That's it! Works everywhere!
```

## 💥 Breaking Change
The `ccds-detect` and `ccds-install-hooks` commands have been removed. 
Everything is now handled by the single `ccds-setup` command.

## 🧪 Tested On
- Windows 11
- Ubuntu in Docker
- WSL2
- Linux VMs

This makes the whole system much simpler - one command that just works on any platform.

🤖 Generated with Claude Code