### PR TITLE
fix: Resolve undefined coreHooksDir variable - v3.7.7

### DIFF
--- a/bin/ccds-setup.cjs
+++ b/bin/ccds-setup.cjs
@@ -88,7 +88,7 @@ const banner = `
 ║    ██        ██        ██   ██        ██                     ║
 ║    ████████  ████████  ██████   ████████                     ║
 ║                                                               ║
-║           CLAUDE CODE DEV STACK V3.7.6                        ║
+║           CLAUDE CODE DEV STACK V3.7.7                        ║
 ║       ∘  ·  Complete One-Command Installation  ·  ∘          ║
 ║                                                               ║
 ║  ·  ∘  ·  *  ·  ∘  ·  *  ·  ∘  ·  *  ·  ∘  ·  *  ·  ∘  ·    ║
@@ -401,7 +401,7 @@ if (fs.existsSync(claudeConfigPath)) {
       version: '3.0.0',
       enabled: true,
       installed: new Date().toISOString(),
-      hooksPath: coreHooksDir
+      hooksPath: hooksDir
     };
     
     fs.writeFileSync(claudeConfigPath, JSON.stringify(config, null, 2));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-dev-stack",
-  "version": "3.7.6",
+  "version": "3.7.7",
   "description": "AI-powered development environment with 37 specialized agents, intelligent hooks, and unified tooling",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Fixed undefined variable `coreHooksDir` at line 404 in ccds-setup.cjs
- Changed to use properly defined `hooksDir` variable
- Version bump to 3.7.7 for bug fix release

## Changes
- Fixed undefined variable reference that could cause setup to fail
- Ensures dev stack metadata properly records the hooks installation path

🤖 Generated with Claude Code