### PR TITLE
fix: Critical hooks initialization bug - v3.7.9

### DIFF
--- a/bin/ccds-setup.cjs
+++ b/bin/ccds-setup.cjs
@@ -88,7 +88,7 @@ const banner = `
 ║    ██        ██        ██   ██        ██                     ║
 ║    ████████  ████████  ██████   ████████                     ║
 ║                                                               ║
-║           CLAUDE CODE DEV STACK V3.7.8                        ║
+║           CLAUDE CODE DEV STACK V3.7.9                        ║
 ║       ∘  ·  Complete One-Command Installation  ·  ∘          ║
 ║                                                               ║
 ║  ·  ∘  ·  *  ·  ∘  ·  *  ·  ∘  ·  *  ·  ∘  ·  *  ·  ∘  ·    ║
@@ -199,7 +199,7 @@ if (fs.existsSync(claudeConfigPath)) {
     let config = JSON.parse(fs.readFileSync(claudeConfigPath, 'utf8'));
     
     // Platform-aware hooks configuration - ALL handled automatically
-    config.hooks = config.hooks || [];
+    config.hooks = config.hooks || {};
     
     // Hooks directory in user's home - works EVERYWHERE
     const hooksDir = path.join(claudeDir, 'hooks');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-dev-stack",
-  "version": "3.7.8",
+  "version": "3.7.9",
   "description": "AI-powered development environment with 37 specialized agents, intelligent hooks, and unified tooling",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Critical Bug Fix

This fixes the root cause of hooks not working in Claude Code.

## The Problem
- Line 202 was initializing `config.hooks` as an empty array `[]`
- Claude expects hooks to be an object with event names as keys
- This was overwriting the correct structure set later in the code

## The Fix
- Changed `config.hooks = config.hooks || []` to `config.hooks = config.hooks || {}`
- Now hooks are properly initialized as an object

## Testing
After installing v3.7.9:
```bash
npm install -g claude-code-dev-stack@latest
ccds-setup
claude --debug
```

You should see:
- "Found X hook matchers in settings" (not 0)
- Hooks executing on tool use
- Proper hook registration

🤖 Generated with Claude Code